### PR TITLE
Make coverage and snapshot Jest options overridable in package.json (…

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -78,6 +78,13 @@ inquirer
     folders.forEach(verifyAbsent);
     files.forEach(verifyAbsent);
 
+    // Prepare Jest config early in case it throws
+    const jestConfig = createJestConfig(
+      filePath => path.posix.join('<rootDir>', filePath),
+      null,
+      true
+    );
+
     console.log();
     console.log(cyan(`Copying files into ${appPath}`));
 
@@ -151,11 +158,7 @@ inquirer
     console.log(cyan('Configuring package.json'));
     // Add Jest config
     console.log(`  Adding ${cyan('Jest')} configuration`);
-    appPackage.jest = createJestConfig(
-      filePath => path.posix.join('<rootDir>', filePath),
-      null,
-      true
-    );
+    appPackage.jest = jestConfig;
 
     // Add Babel config
     console.log(`  Adding ${cyan('Babel')} preset`);

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const fs = require('fs');
+const chalk = require('chalk');
 const paths = require('../../config/paths');
 
 module.exports = (resolve, rootDir, isEjecting) => {
@@ -27,7 +28,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.js?(x)',
-      '<rootDir>/src/**/?(*.)(spec|test).js?(x)'
+      '<rootDir>/src/**/?(*.)(spec|test).js?(x)',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',
@@ -45,6 +46,44 @@ module.exports = (resolve, rootDir, isEjecting) => {
   };
   if (rootDir) {
     config.rootDir = rootDir;
+  }
+  const overrides = Object.assign({}, require(paths.appPackageJson).jest);
+  const supportedKeys = [
+    'collectCoverageFrom',
+    'coverageReporters',
+    'coverageThreshold',
+    'snapshotSerializers',
+  ];
+  if (overrides) {
+    supportedKeys.forEach(key => {
+      if (overrides.hasOwnProperty(key)) {
+        config[key] = overrides[key];
+        delete overrides[key];
+      }
+    });
+    const unsupportedKeys = Object.keys(overrides);
+    if (unsupportedKeys.length) {
+      console.error(
+        chalk.red(
+          'Out of the box, Create React App only supports overriding ' +
+            'these Jest options:\n\n' +
+            supportedKeys.map(key => chalk.bold('  \u2022 ' + key)).join('\n') +
+            '.\n\n' +
+            'These options in your package.json Jest configuration ' +
+            'are not currently supported by Create React App:\n\n' +
+            unsupportedKeys
+              .map(key => chalk.bold('  \u2022 ' + key))
+              .join('\n') +
+            '\n\nIf you wish to override other Jest options, you need to ' +
+            'eject from the default setup. You can do so by running ' +
+            chalk.bold('npm run eject') +
+            ' but remember that this is a one-way operation. ' +
+            'You may also file an issue with Create React App to discuss ' +
+            'supporting more options out of the box.\n'
+        )
+      );
+      process.exit(1);
+    }
   }
   return config;
 };


### PR DESCRIPTION
…#1830)

* Override Jest config collectCoverageFrom with package.json

* Protect against overriding other options

* Better error message

* Create Jest config early on eject

* Tweak wording

* Dry it up

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
